### PR TITLE
Limit concurrent builds

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -43,6 +43,8 @@ create-step() {
   - label: ":docker: :php: v$minor"
     env:
       XDEBUG_VERSION: "$xdebug"
+    concurrency: 5
+    concurrency_group: "f1/docker"
     commands:
       - bash .buildkite/build.sh $version $minor ${php_versions[$version]}
 YAML


### PR DESCRIPTION
As with the Drupal 8 PR, this limits concurrent Docker builds to 5 agents maximum.