### PR TITLE
[WIP] Revert to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION
-FROM php:${PHP_VERSION}-fpm-alpine AS base
+FROM php:${PHP_VERSION}-fpm-alpine3.13 AS base
 
 COPY --from=forumone/f1-ext-install:latest \
   /f1-ext-install \


### PR DESCRIPTION
I have docker 20.10.8 but still ran into a strange issue building https://github.com/forumone/RAM-Support-Wordpress-2019 where wordpress fails build because the `make` xdebug uses is not permitted. See https://github.com/docker-library/php/issues/1130 and https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2 though though I'm not sure the latter is totally related.

To be clear, I'm not suggesting we stick to 3.13, just want to find a better solution and hoping this isn't an omen for others. Stealing this Dockerfile [fixing to PHP 7.3 and xdebug 2.9.8 allowed the build to work](https://github.com/forumone/RAM-Support-Wordpress-2019/pull/579/files).