### PR TITLE
Bump PHP versions

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -14,9 +14,9 @@ declare -A php_versions=(
   # [7.0.33]=""
   # [7.1.33]=""
   [7.2.33]=""
-  [7.3.28]=""
-  [7.4.19]="7"
-  [8.0.6]="8 latest"
+  [7.3.32]=""
+  [7.4.25]="7"
+  [8.0.12]="8 latest"
 )
 
 # XDebug sometimes drops support for EOL'ed PHP versions, so we can't use the stable


### PR DESCRIPTION
This PR bumps PHP versions to address CVE-2021-21703.